### PR TITLE
Update AssetOrganizer.cs

### DIFF
--- a/Editor/AssetOrganizer.cs
+++ b/Editor/AssetOrganizer.cs
@@ -557,6 +557,15 @@ namespace DreadScripts.AssetOrganizer
                 this.path = path;
                 asset = AssetDatabase.LoadAssetAtPath<Object>(path);
                 action = OrganizeAction.Skip;
+            
+                if (asset == null)
+                {
+                    Debug.LogWarning($"Asset at path '{path}' could not be loaded.");
+                    type = typeof(Object); // fallback to avoid NRE
+                    icon = EditorGUIUtility.IconContent("console.warnicon");
+                    return;
+                }
+            
                 type = asset.GetType();
                 icon = new GUIContent(AssetPreview.GetMiniTypeThumbnail(type), type.Name);
             }


### PR DESCRIPTION
Added null check to DependencyAsset

I noticed the tool didn't handle cases well where `AssetDatabase.LoadAssetAtPath()` returns null — usually when dealing with temp files (like `.png~`), missing references, or other stuff Unity doesn't import properly.

This caused a `NullReferenceException` in `DependencyAsset`, since the constructor assumes the asset is always valid and tries to get its type and icon right away.

Added a simple null check to avoid the crash:
- Logs a warning with the file path
- Falls back to `typeof(Object)` so sorting doesn't break
- Uses the warning icon to flag it visually

This keeps the tool stable even when Unity decides to choke on junk files. Nothing changes for valid assets, it just skips the bad ones gracefully now and prints the path and name of the object it couldn't load for users visibility.

```csharp
public DependencyAsset(string path)
{
    this.path = path;
    asset = AssetDatabase.LoadAssetAtPath<Object>(path);
    action = OrganizeAction.Skip;

    if (asset == null)
    {
        Debug.LogWarning($"Asset at path '{path}' could not be loaded.");
        type = typeof(Object); // fallback to avoid NRE
        icon = EditorGUIUtility.IconContent("console.warnicon");
        return;
    }

    type = asset.GetType();
    icon = new GUIContent(AssetPreview.GetMiniTypeThumbnail(type), type.Name);
}